### PR TITLE
Chore: Agregar gema annotate para documentar archivos de modelos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,3 +47,7 @@ group :development, :test do
 end
 
 gem "dotenv-rails", groups: [ :development, :test ]
+
+group :development do
+  gem "annotate"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,9 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    annotate (2.6.5)
+      activerecord (>= 2.3.0)
+      rake (>= 0.8.7)
     ast (2.4.2)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
@@ -301,6 +304,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  annotate
   bootsnap
   brakeman
   debug

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,34 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults({
+      "position_in_routes"   => "before",
+      "position_in_class"    => "before",
+      "position_in_test"     => "before",
+      "position_in_fixture"  => "before",
+      "position_in_factory"  => "before",
+      "show_indexes"         => "true",
+      "simple_indexes"       => "false",
+      "model_dir"            => "app/models",
+      "include_version"      => "false",
+      "require"              => "",
+      "exclude_tests"        => "false",
+      "exclude_fixtures"     => "false",
+      "exclude_factories"    => "false",
+      "ignore_model_sub_dir" => "false",
+      "skip_on_db_migrate"   => "false",
+      "format_bare"          => "true",
+      "format_rdoc"          => "false",
+      "format_markdown"      => "false",
+      "sort"                 => "false",
+      "force"                => "false",
+      "trace"                => "false"
+    })
+  end
+
+  Annotate.load_tasks
+end


### PR DESCRIPTION
Se agrega gema annotate y su archivo de configuración para comenzar a documentar los modelos con sus atributos.